### PR TITLE
修正忽略来源网站的一个逻辑错误

### DIFF
--- a/assets/travelling.js
+++ b/assets/travelling.js
@@ -150,11 +150,13 @@ function travelling(){
 
 
     if (document.referrer) {
-      var origin = new URL(document.referrer).origin;
-      url.splice(url.indexOf(origin), 1);
+        var origin = new URL(document.referrer).origin;
+        if (url.includes(origin) {
+            url.splice(url.indexOf(origin), 1);
+        }
     }
     
     
     var ints=Math.floor(Math.random() * url.length);
     window.location=url[ints];
-   }
+}


### PR DESCRIPTION
非常抱歉，#199 遗漏了“来源网站 (`referrer`) 不在名单里”的情况，这种情况下会错误地忽略列表中最后一个网站。这个 PR 修复了此问题。