### PR TITLE
fix: Error running `pnpm cli` with `websiteUrl` in issues running action

### DIFF
--- a/.github/workflows/issue-open.yml
+++ b/.github/workflows/issue-open.yml
@@ -121,6 +121,9 @@ jobs:
             fs.writeFileSync('./travellings-bot/url.txt', websiteUrl);
       # - name: ls
       #   run: ls
+      - name: Install Chrome
+        run: npx puppeteer browsers install chrome
+        
       - name: Run pnpm cli with websiteUrl
         run: |
           websiteUrl=$(head -n 1 url.txt)


### PR DESCRIPTION
Test case: <https://github.com/mtftm/travellings/actions/runs/15394623437/job/43312100467>