### PR TITLE
Train跳转页面的备份数据随机跳转

### DIFF
--- a/public/train.html
+++ b/public/train.html
@@ -267,16 +267,38 @@
         function getSetting(key) {
             return localStorage.getItem(prefix + key);
         }
+        async function RandomWebSiteFromJson() {
+            const res = await fetch("https://backup.api.travellings.cn/list.json");
+            const json = await res.json();
+
+            if (!json.success || !Array.isArray(json.data)) {
+                throw new Error("bad json");
+            }
+
+            const randomSite = json.data[Math.floor(Math.random() * json.data.length)];
+
+            return {
+                name: randomSite.name.trim(),
+                url: randomSite.url.trim()
+            };
+        }
         async function requestRandomWebsite(tag = getSetting("tag")) {
-            const res = await fetch(`https://api.travellings.cn/random${tag ? `?tag=${tag}` : ''}`);
-            const data = await res.json();
-            if (data.success) {
-                return {
-                    name: data.data[0].name.trim(),
-                    url: data.data[0].url.trim()
-                };
-            } else {
-                throw new Error("NO");
+            try {
+                const res = await fetch(`https://api.travellings.cn/random${tag ? `?tag=${tag}` : ''}`);
+                const data = await res.json();
+
+                if (data.success && data.data.length > 0) {
+                    return {
+                        name: data.data[0].name.trim(),
+                        url: data.data[0].url.trim()
+                    };
+                } else {
+                    console.log("主 API 返回失败，现在尝试从备用 JSON 获取");
+                    return RandomWebsiteFromJson();
+                }
+            } catch (err) {
+                console.warn("主 API 请求失败，使用备用 JSON:", err);
+                return RandomWebsiteFromJson();
             }
         }
         async function RandomTest(tag = getSetting("tag")) {


### PR DESCRIPTION
您好，我已为我开发的Train跳转页面增加了如下方法：当api请求失败时，从https://backup.api.travellings.cn/list.json 获取全量的成员数据，通过 JavaScript 方法实现随机跳转